### PR TITLE
Fixed /C input validation regex

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -2811,13 +2811,13 @@ void generateWebConfigPage(bool printOnly) {
        printFmtToWebClient(PSTR("<input type=text id='option_%d' name='option_%d' "), cfg.id + 1, cfg.id + 1);
        switch (cfg.var_type) {
          case CDT_MAC:
-           printToWebClient(PSTR("pattern='((^|,)([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2}))*$'"));
+           printToWebClient(PSTR("pattern='([0-9A-Fa-f]{2}[-:]){5}[0-9A-Fa-f]{2}'"));
            break;
          case CDT_IPV4:
-           printToWebClient(PSTR("pattern='((^|\\.)((25[0-5])|(2[0-4]\\d)|(1\\d\\d)|([1-9]?\\d))){4}'"));
+           printToWebClient(PSTR("pattern='((^|\\.)(25[0-5]|2[0-4]\\d|[01]?\\d{1,2})){4}'"));
            break;
          case CDT_PROGNRLIST:
-           printToWebClient(PSTR("pattern='(((^|,)((\\d){1,5})((\\.){0,1})((\\d){0,1})((\\!){0,1})((\\d){0,2})))*'"));
+           printToWebClient(PSTR("pattern='((^|,)\\d{1,5}(\\.\\d)?(!\\d{1,2})?)+'"));
            break;
          }
        printToWebClient(PSTR(" value='"));
@@ -3074,10 +3074,6 @@ char *GetDateTime(char *date) {
             currentDate.elements.month = now.tm_mon + 1,
             currentDate.elements.year  = now.tm_year + 1900,
             now.tm_hour,now.tm_min,now.tm_sec);
-#if 0 // for accelerated testing:
-  currentDate.elements.day   = now.tm_min % 10 + 1;
-  currentDate.elements.month = now.tm_min / 10 + 1;
-#endif
 #else
   sprintf_P(date,PSTR("%02d.%02d.%d %02d:%02d:%02d"),
             currentDate.elements.day   = day(),

--- a/BSB_LAN/BSB_LAN_config.h.default
+++ b/BSB_LAN/BSB_LAN_config.h.default
@@ -216,7 +216,7 @@ float ipwe_parameters[80] = {
 // compression (what browser doesn't?), it is sufficient to copy the *.gz file versions to your
 // bsb-lan unit, but omit the ".gz" from the path names you put into the following lines!
 // (*) In case you're using an ESP32's internal memory instead of an SD card, use
-// https://github.com/lorol/arduino-esp32littlefs-plugin to upload the files.
+// https://github.com/me-no-dev/arduino-esp32fs-plugin to upload the files.
 // For local use of these libraries to work, "#define WEBSERVER" is also required!
 //#define D3_LIBRARY_PATH "/d3.js"
 //#define C3_LIBRARY_PATH "/c3.js"


### PR DESCRIPTION
...for CDT_PROGNRLIST
![image](https://user-images.githubusercontent.com/105788188/230768186-83d4f375-2f83-4446-a806-cab05fe0a574.png)
...and cleaned up regex for CDT_MAC and CDT_IPV4 as well

also: removed test code in `GetDateTime()` (which was disabled by `#ifdef 0` anyway)